### PR TITLE
bug in PHP 7.2

### DIFF
--- a/src/Xl/Worksheets/SheetXml.php
+++ b/src/Xl/Worksheets/SheetXml.php
@@ -253,7 +253,7 @@ class SheetXml
      */
     private function getIntCell($cellName, $cellIndex, $value)
     {
-        return '<c r="'.$cellName.'" s="'.$cellIndex.'" t="n"><v>'.($value * 1).'</v></c>';
+        return '<c r="'.$cellName.'" s="'.$cellIndex.'" t="n"><v>'.intval($value).'</v></c>';
     }
 
     /**


### PR DESCRIPTION
Денис, в PHP 7.2 стало падать исключение "A non well formed numeric value encountered"
при поле вида $value = '123423234 ', с пробелом на конце 

Возможно я что-то не учёл, но в моём случае проблема решилась заменой приведения к INT вида
$value * 1 на intVal($value)
