### PR TITLE
php 7.4 curly brackets fix

### DIFF
--- a/src/Xl/Worksheets/SheetXml.php
+++ b/src/Xl/Worksheets/SheetXml.php
@@ -179,7 +179,7 @@ class SheetXml
             return '<c r="'.$cellName.'" s="'.$cellIndex.'"/>';
         }
 
-        if (is_string($value) && $value{0} == '=') {
+        if (is_string($value) && $value[0] == '=') {
             return $this->getFormulaCell($cellName, $cellIndex, $value);
         }
 
@@ -204,8 +204,8 @@ class SheetXml
         if (!is_string($value)) {
             return $this->getIntCell($cellName, $cellIndex, $value);
         } else {
-            if ($value{0} != '0' &&
-                $value{0} != '+' &&
+            if ($value[0] != '0' &&
+                $value[0] != '+' &&
                 filter_var(
                     $value,
                     FILTER_VALIDATE_INT,


### PR DESCRIPTION
Денис, добрый день.

В PHP 7.4 обращение к элементу массива через {} теперь не работает.
Исправил, работает. Пока других багов с 7.4 не вылезало.